### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -64,14 +64,14 @@ func NewStandardFilterer() *StandardFilterer {
 	}
 }
 
-// Add the specified filter.
+// AddFilter adds the specified filter.
 func (self *StandardFilterer) AddFilter(filter Filter) {
 	if !self.filters.SetContains(filter) {
 		self.filters.SetAdd(filter)
 	}
 }
 
-// Remove the specified filter.
+// RemoveFilter removes the specified filter.
 func (self *StandardFilterer) RemoveFilter(filter Filter) {
 	if self.filters.SetContains(filter) {
 		self.filters.SetRemove(filter)
@@ -94,7 +94,7 @@ func (self *StandardFilterer) Filter(record *LogRecord) int {
 	return recordVote
 }
 
-// Return all the filter in this filterer.
+// GetFilters returns all the filter in this filterer.
 func (self *StandardFilterer) GetFilters() *ListSet {
 	return self.filters
 }

--- a/formatter.go
+++ b/formatter.go
@@ -153,7 +153,7 @@ func NewStandardFormatter(format string, dateFormat string) *StandardFormatter {
 	}
 }
 
-// Return the creation time of the specified LogRecord as formatted text.
+// FormatTime returns the creation time of the specified LogRecord as formatted text.
 // This method should be called from Format() by a formatter which wants to
 // make use of a formatted time. This method can be overridden in formatters
 // to provide for any specific requirement, but the basic behaviour is as
@@ -196,12 +196,12 @@ func NewBufferingFormatter(lineFormatter Formatter) *BufferingFormatter {
 	}
 }
 
-// Return the header string for the specified records.
+// FormatHeader returns the header string for the specified records.
 func (self *BufferingFormatter) FormatHeader(_ []*LogRecord) string {
 	return ""
 }
 
-// Return the footer string for the specified records.
+// FormatFooter returns the footer string for the specified records.
 func (self *BufferingFormatter) FormatFooter(_ []*LogRecord) string {
 	return ""
 }

--- a/handler_file.go
+++ b/handler_file.go
@@ -145,7 +145,7 @@ func NewFileHandler(filename string, mode int, bufferSize int) (*FileHandler, er
 	return object, nil
 }
 
-// Return the absolute path of logging file.
+// GetFilePath returns the absolute path of logging file.
 func (self *FileHandler) GetFilePath() string {
 	return self.filepath
 }

--- a/handler_rotating_file.go
+++ b/handler_rotating_file.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// Check whether the specified directory/file exists or not.
+// FileExists checks whether the specified directory/file exists or not.
 func FileExists(filename string) bool {
 	if _, err := os.Stat(filename); err != nil {
 		if os.IsNotExist(err) {

--- a/handler_socket.go
+++ b/handler_socket.go
@@ -165,7 +165,7 @@ func (self *SocketHandler) Handle(record *LogRecord) int {
 	return self.Handle2(self, record)
 }
 
-// Handles an error during logging.
+// HandleError handles an error during logging.
 // An error has occurred during logging. Most likely cause connection lost.
 // Close the socket so that we can retry on the next event.
 func (self *SocketHandler) HandleError(record *LogRecord, err error) {

--- a/handler_stream.go
+++ b/handler_stream.go
@@ -32,7 +32,7 @@ func NewStreamHandler(
 	return object
 }
 
-// Return the underlying stream.
+// GetStream returns the underlying stream.
 func (self *StreamHandler) GetStream() Stream {
 	return self.stream
 }

--- a/init.go
+++ b/init.go
@@ -56,7 +56,7 @@ func initialize() {
 	Closer = NewHandlerCloser()
 }
 
-// Ensure all log messages are flushed before program exits.
+// Shutdown ensures all log messages are flushed before program exits.
 func Shutdown() {
 	Closer.Close()
 	initialize()
@@ -67,7 +67,7 @@ func SetLoggerMaker(maker LoggerMaker) {
 	manager.SetLoggerMaker(maker)
 }
 
-// Return a logger with the specified name, creating it if necessary.
+// GetLogger returns a logger with the specified name, creating it if necessary.
 // If empty name is specified, return the root logger.
 func GetLogger(name string) Logger {
 	if len(name) > 0 {

--- a/level.go
+++ b/level.go
@@ -61,7 +61,7 @@ func getLevelName(level LogLevelType) (name string, ok bool) {
 	return levelName, ok
 }
 
-// Return the textual representation of specified logging level.
+// GetLevelName returns the textual representation of specified logging level.
 // If the level is one of the predefined levels (LevelFatal, LevelError,
 // LevelWarn, LevelInfo, LevelDebug) then you get the corresponding string.
 // If you have registered level with name using AddLevel() then the name you

--- a/logger.go
+++ b/logger.go
@@ -52,7 +52,7 @@ func (self *PlaceHolder) Type() NodeType {
 	return NodePlaceHolder
 }
 
-// Add the specified logger as a child of this PlaceHolder.
+// Append adds the specified logger as a child of this PlaceHolder.
 func (self *PlaceHolder) Append(logger Logger) {
 	if !self.Loggers.SetContains(logger) {
 		self.Loggers.SetAdd(logger)
@@ -260,7 +260,7 @@ func (self *StandardLogger) IsEnabledFor(level LogLevelType) bool {
 	return level >= self.GetEffectiveLevel()
 }
 
-// Get the effective level for this logger.
+// GetEffectiveLevel gets the effective level for this logger.
 // Loop through this logger and its parents in the logger hierarchy,
 // looking for a non-zero logging level. Return the first one found.
 func (self *StandardLogger) GetEffectiveLevel() LogLevelType {
@@ -501,7 +501,7 @@ func (self *StandardLogger) SetParent(parent Logger) {
 	self.parent = parent
 }
 
-// Get a logger which is descendant to this one.
+// GetChild gets a logger which is descendant to this one.
 // This is a convenience method, such that
 //     logging.GetLogger("abc").GetChild("def.ghi")
 // is the same as
@@ -565,7 +565,7 @@ func (self *Manager) SetLoggerMaker(maker LoggerMaker) {
 	self.loggerMaker = maker
 }
 
-// Get a logger with the specified name (channel name), creating it
+// GetLogger gets a logger with the specified name (channel name), creating it
 // if it doesn't yet exists. This name is a dot-separated hierarchical
 // name, such as "a", "a.b", "a.b.c" or similar.
 //

--- a/record.go
+++ b/record.go
@@ -55,13 +55,13 @@ func NewLogRecord(
 	}
 }
 
-// Return the string representation for this LogRecord.
+// String returns the string representation for this LogRecord.
 func (self *LogRecord) String() string {
 	return fmt.Sprintf("<LogRecord: %s, %s, %s, %d, \"%s\">",
 		self.Name, self.Level, self.PathName, self.LineNo, self.Message)
 }
 
-// Return the message for this LogRecord.
+// GetMessage returns the message for this LogRecord.
 // The message is composed of the Message and any user-supplied arguments.
 func (self *LogRecord) GetMessage() string {
 	if len(self.Message) == 0 {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?